### PR TITLE
Made maps actual hash-maps instead of linear arrays

### DIFF
--- a/core/codegen/arithmetic.go
+++ b/core/codegen/arithmetic.go
@@ -52,6 +52,11 @@ func (b *Builder) Not(x *Value) *Value {
 	return b.val(b.m.Types.Bool, b.llvm.CreateNot(x.llvm, ""))
 }
 
+// Not returns ~x.
+func (b *Builder) Invert(x *Value) *Value {
+	return b.val(x.ty, b.llvm.CreateNot(x.llvm, ""))
+}
+
 func (b *Builder) cmp(x *Value, op string, y *Value, ucmp, scmp llvm.IntPredicate, fcmp llvm.FloatPredicate) *Value {
 	assertTypesEqual(x.Type(), y.Type())
 	ty := x.Type()
@@ -205,6 +210,23 @@ func (b *Builder) Div(x, y *Value) *Value {
 	}
 }
 
+// Div returns x % y. The types of the two values must be equal.
+func (b *Builder) Rem(x, y *Value) *Value {
+	assertTypesEqual(x.Type(), y.Type())
+	ty := Scalar(x.Type())
+	name := x.Name() + "%" + y.Name()
+	switch {
+	case IsSignedInteger(ty):
+		return b.val(ty, b.llvm.CreateSRem(x.llvm, y.llvm, name))
+	case IsUnsignedInteger(ty):
+		return b.val(ty, b.llvm.CreateURem(x.llvm, y.llvm, name))
+	case IsFloat(ty):
+		return b.val(ty, b.llvm.CreateFRem(x.llvm, y.llvm, name))
+	default:
+		panic(fmt.Errorf("Cannot divide values of type %v", ty))
+	}
+}
+
 // DivS returns x / y. The types of the two values must be equal.
 func (b *Builder) DivS(x *Value, y interface{}) *Value {
 	return b.Div(x, b.Scalar(y))
@@ -222,6 +244,13 @@ func (b *Builder) And(x, y *Value) *Value {
 func (b *Builder) Or(x, y *Value) *Value {
 	assertTypesEqual(x.Type(), y.Type())
 	return b.val(x.Type(), b.llvm.CreateOr(x.llvm, y.llvm, x.Name()+"|"+y.Name()))
+}
+
+// Xor performs a bitwise-xor of the two integers.
+// The types of the two values must be equal.
+func (b *Builder) Xor(x, y *Value) *Value {
+	assertTypesEqual(x.Type(), y.Type())
+	return b.val(x.Type(), b.llvm.CreateXor(x.llvm, y.llvm, x.Name()+"^"+y.Name()))
 }
 
 // Shuffle performs a vector-shuffle operation of the two vector values x and y
@@ -250,7 +279,15 @@ func (b *Builder) ShiftLeft(x, y *Value) *Value {
 // ShiftRight performs a bit-shift right by shift bits.
 func (b *Builder) ShiftRight(x, y *Value) *Value {
 	assertTypesEqual(x.Type(), y.Type())
-	return b.val(x.Type(), b.llvm.CreateAShr(x.llvm, y.llvm, x.Name()+">>"+y.Name()))
+	ty := x.Type()
+	switch {
+	case IsSignedInteger(ty):
+		return b.val(ty, b.llvm.CreateAShr(x.llvm, y.llvm, x.Name()+">>"+y.Name()))
+	case IsUnsignedInteger(ty):
+		return b.val(ty, b.llvm.CreateLShr(x.llvm, y.llvm, x.Name()+">>"+y.Name()))
+	default:
+		panic(fmt.Errorf("Cannot divide values of type %v", ty))
+	}
 }
 
 // Scalar returns a constant scalar with the value v.

--- a/gapil/compiler/BUILD.bazel
+++ b/gapil/compiler/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "errors.go",
         "expressions.go",
         "externs.go",
+        "map.go",
         "program.go",
         "refcount.go",
         "scope.go",

--- a/gapil/compiler/map.go
+++ b/gapil/compiler/map.go
@@ -1,0 +1,427 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/google/gapid/core/codegen"
+	"github.com/google/gapid/gapil/semantic"
+)
+
+// This is a basic linear-probing hash map
+// It works out to the following implementation
+// enum used {
+//    empty,
+//    full,
+//    previously_full
+// }
+// struct element {
+//    used used;
+//    KeyType k;
+//    ValueType v;
+// }
+// struct Map {
+//    uint64_t count;
+//    uint64_t capacity;
+//    element* elements;
+// }
+
+// In order to look up something in the map
+// 1) h = Hashed Key % capacity
+// 2) Check element[h].
+//  If used == empty, then the element does not exist in the map
+// 3) If used == previously_full, then it is not here, check h = h + 1: goto 2
+// 4) If used == full, if k != key: h = h + 1: goto 2, otherwise you found it
+
+// Removal is as simple as
+// 1) Find element
+// 2) set used == previously_full
+
+// Once the map hits > 80% capacity, we should rehash the map larger.
+//  Otherwise collisions will turn this into a linear search.
+
+// Insertion into the map is similar (assuming it doesn't exist)
+//   1) h = Hashed Key % capacity
+//   2) rehash if necessary
+//   3) find first bucket >= h, where used != full (mod capacity)
+//   4) Insert there, mark used = full
+
+// TODO: Investigate alternative rehash rule.
+//     Right now it is new_capacity = capacity + 16, likely we want new_capacity = capacity << 1
+// TODO: Investigate rehashing once #full + #previously_full > 80%
+//     If we end up with lots of insertions/deletions, this will prevent linear search
+
+const emptyBucket = uint64(0)
+const fullBucket = uint64(1)
+const usedBucket = uint64(2)
+
+func (c *compiler) defineMapType(t *semantic.Map) {
+	mapPtrTy := c.ty.target[t].(codegen.Pointer)
+	mapStrTy := mapPtrTy.Element.(*codegen.Struct)
+	keyTy := c.targetType(t.KeyType)
+	valTy := c.targetType(t.ValueType)
+	elTy := c.ty.Struct(fmt.Sprintf("%v…%v", keyTy.TypeName(), valTy.TypeName()),
+		// Used: 0 == empty, 1 == has a key, 2 == doesn't have a key, but
+		//    can't assume your searched key doesn't exist
+		codegen.Field{Name: "used", Type: c.targetType(semantic.Uint64Type)},
+		codegen.Field{Name: "k", Type: keyTy},
+		codegen.Field{Name: "v", Type: valTy},
+	)
+	mapStrTy.SetBody(false,
+		codegen.Field{Name: mapRefCount, Type: c.ty.Uint32},
+		codegen.Field{Name: mapCount, Type: c.ty.Uint64},
+		codegen.Field{Name: mapCapacity, Type: c.ty.Uint64},
+		codegen.Field{Name: mapElements, Type: c.ty.Pointer(elTy)},
+	)
+	c.ty.maps[t] = &MapInfo{Type: mapStrTy, Elements: elTy, Key: keyTy, Val: valTy}
+
+	c.buildMapType(t)
+}
+
+// If we know the values are going to be small & sequential, we can
+// swap out this hash.
+func (c *compiler) hash64Bit(s *scope, value *codegen.Value) *codegen.Value {
+	rotateRight := func(value *codegen.Value, bits int) *codegen.Value {
+		v := s.ShiftRight(value, s.Scalar(uint64(bits)))
+		v = s.ShiftLeft(value, s.Scalar(uint64(64-bits)))
+		v = s.Or(v, v)
+		return v.SetName(">>>")
+	}
+
+	shiftLeft := func(value *codegen.Value, bits int) *codegen.Value {
+		return s.ShiftLeft(value, s.Scalar(uint64(bits)))
+	}
+
+	v := value
+	v = s.Invert(v).SetName("_hash1")
+	v = s.Add(v, shiftLeft(v, 21)).SetName("_hash2")
+	v = s.Xor(v, rotateRight(v, 24)).SetName("_hash3")
+	v = s.Add(s.Add(v, shiftLeft(v, 3)), shiftLeft(v, 8)).SetName("_hash4")
+	v = s.Xor(v, rotateRight(v, 14)).SetName("_hash5")
+	v = s.Add(s.Add(v, shiftLeft(v, 2)), shiftLeft(v, 4)).SetName("_hash6")
+	v = s.Xor(v, rotateRight(v, 28)).SetName("_hash7")
+	v = s.Add(v, shiftLeft(v, 31)).SetName("_hash8")
+	return v
+}
+
+func (c *compiler) hashVariableValue(s *scope, pointer *codegen.Value, numBytes *codegen.Value) *codegen.Value {
+	u64Type := c.targetType(semantic.Uint64Type)
+	numBytes = numBytes.Load().Cast(u64Type)
+	v := s.Local("_hash", u64Type)
+	v.Store(s.Scalar(uint64(0)))
+	s.ForN(numBytes, func(it *codegen.Value) *codegen.Value {
+		tv := v.Load()
+		l6 := s.ShiftLeft(tv, s.Scalar(uint64(6)))
+		l16 := s.ShiftLeft(tv, s.Scalar(uint64(16)))
+		dat := pointer.Index(0, it).Load().Cast(u64Type)
+		r := s.Add(dat, l6)
+		r = s.Add(r, l16)
+		r = s.Add(r, tv)
+		v.Store(r)
+		return nil
+	})
+	return v.Load()
+}
+
+func (c *compiler) hashValue(s *scope, t semantic.Type, value *codegen.Value) *codegen.Value {
+	keyType := c.targetType(t)
+	u64Type := c.targetType(semantic.Uint64Type)
+	u32Type := c.targetType(semantic.Uint32Type)
+	if keyType != value.Type() {
+		fail("hashValue must be called with the given type, %+v, %+v", keyType, value.Type())
+	}
+
+	switch t := semantic.Underlying(t).(type) {
+	case *semantic.Builtin:
+		switch t {
+		case semantic.BoolType:
+			return c.hash64Bit(s, value.Cast(u64Type))
+		case semantic.IntType:
+			return c.hash64Bit(s, value.Cast(u64Type))
+		case semantic.UintType:
+			return c.hash64Bit(s, value.Cast(u64Type))
+		case semantic.SizeType:
+			return c.hash64Bit(s, value.Cast(u64Type))
+		case semantic.CharType:
+			return c.hash64Bit(s, value.Cast(u64Type))
+		case semantic.Int8Type:
+			return c.hash64Bit(s, value.Cast(u64Type))
+		case semantic.Uint8Type:
+			return c.hash64Bit(s, value.Cast(u64Type))
+		case semantic.Int16Type:
+			return c.hash64Bit(s, value.Cast(u64Type))
+		case semantic.Uint16Type:
+			return c.hash64Bit(s, value.Cast(u64Type))
+		case semantic.Int32Type:
+			return c.hash64Bit(s, value.Cast(u64Type))
+		case semantic.Uint32Type:
+			return c.hash64Bit(s, value.Cast(u64Type))
+		case semantic.Int64Type:
+			return c.hash64Bit(s, value.Cast(u64Type))
+		case semantic.Uint64Type:
+			return c.hash64Bit(s, value.Cast(u64Type))
+		case semantic.Float32Type:
+			return c.hash64Bit(s, value.Bitcast(u32Type).Cast(u64Type))
+		case semantic.Float64Type:
+			return c.hash64Bit(s, value.Bitcast(u32Type))
+		case semantic.StringType:
+			return c.hashVariableValue(s, value.Index(0, "data"), value.Index(0, "length"))
+		default:
+			fail("Cannot determine the hash for %T, %v", t, t)
+			return nil
+		}
+	case *semantic.StaticArray:
+		fail("Cannot use a static array as a hash key")
+		return nil
+	case *semantic.Pointer:
+		fail("Cannot use a pointer array as a hash key")
+		return nil
+	case *semantic.Reference:
+		fail("Cannot use a reference array as a hash key")
+		return nil
+	case *semantic.Class:
+		// Cannot hash a class
+		fail("Cannot hash a class")
+		return nil
+	default:
+		fail("Cannot determine the hash of %T", t)
+		return nil
+	}
+}
+
+func (c *compiler) buildMapType(t *semantic.Map) {
+	info, ok := c.ty.maps[t]
+	if !ok {
+		fail("Unknown map")
+	}
+
+	mapPtrTy := c.targetType(t)
+	elTy, keyTy, valTy := info.Elements, info.Key, info.Val
+	valPtrTy := c.ty.Pointer(valTy)
+	u64Type := c.targetType(semantic.Uint64Type)
+
+	contains := c.module.Function(c.ty.Bool, t.Name()+"_contains", c.ty.ctxPtr, mapPtrTy, keyTy)
+	c.build(contains, func(s *scope) {
+		m := s.Parameter(1).SetName("map")
+		k := s.Parameter(2).SetName("key")
+		h := c.hashValue(s, t.KeyType, k)
+		capacity := m.Index(0, mapCapacity).Load()
+		elements := m.Index(0, mapElements).Load()
+		s.ForN(capacity, func(it *codegen.Value) *codegen.Value {
+			check := s.Rem(s.Add(h, it), capacity)
+			valid := elements.Index(check, "used").Load()
+			s.If(c.equal(s, valid, s.Scalar(emptyBucket)), func() {
+				s.Return(s.Scalar(false))
+			})
+			s.If(c.equal(s, valid, s.Scalar(fullBucket)), func() {
+				key := elements.Index(check, "k")
+				found := c.equal(s, key.Load(), k)
+				s.If(found, func() { s.Return(s.Scalar(true)) })
+			})
+			return nil
+		})
+		s.Return(s.Scalar(false))
+	})
+
+	index := c.module.Function(valPtrTy, t.Name()+"_index", c.ty.ctxPtr, mapPtrTy, keyTy, c.ty.Bool)
+	f32Type := c.targetType(semantic.Float32Type)
+	c.build(index, func(s *scope) {
+		m := s.Parameter(1).SetName("map")
+		k := s.Parameter(2).SetName("key")
+		addIfNotFound := s.Parameter(3).SetName("addIfNotFound")
+
+		countPtr := m.Index(0, mapCount)
+		capacityPtr := m.Index(0, mapCapacity)
+		elementsPtr := m.Index(0, mapElements)
+		count := countPtr.Load()
+		capacity := capacityPtr.Load()
+		elements := elementsPtr.Load()
+
+		h := c.hashValue(s, t.KeyType, k)
+		// Search for existing
+		s.ForN(capacity, func(it *codegen.Value) *codegen.Value {
+			check := s.Rem(s.Add(h, it), capacity)
+			valid := elements.Index(check, "used").Load()
+			s.If(c.equal(s, valid, s.Scalar(fullBucket)), func() {
+				found := c.equal(s, elements.Index(check, "k").Load(), k)
+				s.If(found, func() {
+					s.Return(elements.Index(check, "v"))
+				})
+			})
+
+			return s.Not(c.equal(s, valid, s.Scalar(emptyBucket)))
+		})
+
+		s.If(addIfNotFound, func() {
+			resize := s.LocalInit("resize", elements.IsNull())
+			s.If(s.Not(resize.Load()), func() {
+				used := s.Div(count.Cast(f32Type), capacity.Cast(f32Type))
+				resize.Store(s.GreaterThan(used, s.Scalar(float32(mapMaxCapacity))))
+			})
+
+			getStorageBucket := func(k, h, table, tablesize *codegen.Value) *codegen.Value {
+				newBucket := s.Local("newBucket", u64Type)
+				s.ForN(tablesize, func(it *codegen.Value) *codegen.Value {
+					check := s.Rem(s.Add(h, it), tablesize).SetName("hash_bucket")
+					newBucket.Store(check)
+					valid := table.Index(check, "used").Load()
+					notFound := c.equal(s, valid, s.Scalar(fullBucket))
+					return notFound
+				})
+				return newBucket.Load()
+			}
+
+			s.If(resize.Load(), func() {
+				// Grow
+				s.IfElse(elements.IsNull(), func() {
+					capacity := s.AddS(capacity, uint64(mapGrowBy))
+					capacityPtr.Store(capacity)
+					elements := c.alloc(s, capacity, elTy)
+					elementsPtr.Store(elements)
+					s.ForN(capacity, func(it *codegen.Value) *codegen.Value {
+						elements.Index(it, "used").Store(s.Scalar(emptyBucket))
+						return nil
+					})
+				}, /* else */ func() {
+					newCapacity := s.AddS(capacity, uint64(mapGrowBy))
+					capacityPtr.Store(newCapacity)
+					newElements := c.alloc(s, newCapacity, elTy)
+					s.ForN(newCapacity, func(it *codegen.Value) *codegen.Value {
+						newElements.Index(it, "used").Store(s.Scalar(emptyBucket))
+						return nil
+					})
+
+					s.ForN(capacity, func(it *codegen.Value) *codegen.Value {
+						valid := elements.Index(it, "used").Load()
+						s.If(c.equal(s, valid, s.Scalar(fullBucket)), func() {
+							k := elements.Index(it, "k").Load()
+							v := elements.Index(it, "v").Load()
+							h := c.hashValue(s, t.KeyType, k)
+							bucket := getStorageBucket(k, h, newElements, newCapacity)
+							newElements.Index(bucket, "k").Store(k)
+							newElements.Index(bucket, "v").Store(v)
+							newElements.Index(bucket, "used").Store(s.Scalar(fullBucket))
+						})
+						return nil
+					})
+					c.free(s, elements)
+					elementsPtr.Store(newElements)
+				})
+			})
+
+			count := countPtr.Load()
+			capacity := capacityPtr.Load()
+			elements := elementsPtr.Load()
+			bucket := getStorageBucket(k, h, elements, capacity)
+			elements.Index(bucket, "k").Store(k)
+			elements.Index(bucket, "used").Store(s.Scalar(fullBucket))
+			valPtr := elements.Index(bucket, "v")
+			v := c.initialValue(s, t.ValueType)
+			valPtr.Store(v)
+			countPtr.Store(s.AddS(count, uint64(1)))
+
+			c.reference(s, v, t.ValueType)
+			c.reference(s, k, t.KeyType)
+
+			s.Return(valPtr)
+		})
+	})
+
+	lookup := c.module.Function(valTy, t.Name()+"_lookup", c.ty.ctxPtr, mapPtrTy, keyTy)
+	c.build(lookup, func(s *scope) {
+		m := s.Parameter(1).SetName("map")
+		k := s.Parameter(2).SetName("key")
+		ptr := s.Call(index, s.ctx, m, k, s.Scalar(false))
+		s.If(ptr.IsNull(), func() {
+			s.Return(c.initialValue(s, t.ValueType))
+		})
+		v := ptr.Load()
+		c.reference(s, v, t.ValueType)
+		s.Return(v)
+	})
+
+	remove := c.module.Function(c.ty.Void, t.Name()+"_remove", c.ty.ctxPtr, mapPtrTy, keyTy)
+	c.build(remove, func(s *scope) {
+		m := s.Parameter(1).SetName("map")
+		k := s.Parameter(2).SetName("key")
+		countPtr := m.Index(0, mapCount)
+		capacity := m.Index(0, mapCapacity).Load()
+		h := c.hashValue(s, t.KeyType, k)
+		elements := m.Index(0, mapElements).Load()
+		// Search for existing
+		s.ForN(capacity, func(it *codegen.Value) *codegen.Value {
+			check := s.Rem(s.Add(h, it), capacity)
+			valid := elements.Index(check, "used").Load()
+			s.If(c.equal(s, valid, s.Scalar(fullBucket)), func() {
+				found := c.equal(s, elements.Index(check, "k").Load(), k)
+				s.If(found, func() {
+					elPtr := elements.Index(check)
+					// Release references to el
+					if c.isRefCounted(t.KeyType) {
+						c.release(s, elPtr.Index(0, "k").Load(), t.KeyType)
+					}
+					if c.isRefCounted(t.ValueType) {
+						c.release(s, elPtr.Index(0, "v").Load(), t.ValueType)
+					}
+					// Replace element with last
+					elPtr.Index(0, "used").Store(s.Scalar(usedBucket))
+					count := countPtr.Load()
+					countM1 := s.SubS(count, uint64(1)).SetName("count-1")
+					// Decrement count
+					countPtr.Store(countM1)
+					s.Return(nil)
+				})
+			})
+
+			return s.Not(c.equal(s, valid, s.Scalar(emptyBucket)))
+		})
+	})
+
+	clear := c.module.Function(nil, t.Name()+"_clear", c.ty.ctxPtr, mapPtrTy)
+	c.build(clear, func(s *scope) {
+		m := s.Parameter(1).SetName("map")
+		capacity := m.Index(0, mapCapacity).Load()
+		elements := m.Index(0, mapElements).Load()
+		if c.isRefCounted(t.KeyType) || c.isRefCounted(t.ValueType) {
+			s.ForN(capacity, func(it *codegen.Value) *codegen.Value {
+				valid := elements.Index(it, "used").Load()
+				s.If(c.equal(s, valid, s.Scalar(fullBucket)), func() {
+					if c.isRefCounted(t.KeyType) {
+						c.release(s, elements.Index(it, "k").Load(), t.KeyType)
+					}
+					if c.isRefCounted(t.ValueType) {
+						c.release(s, elements.Index(it, "v").Load(), t.ValueType)
+					}
+				})
+				return nil
+			})
+		}
+		c.free(s, elements)
+		m.Index(0, mapCount).Store(s.Scalar(uint64(0)))
+		m.Index(0, mapCapacity).Store(s.Scalar(uint64(0)))
+	})
+
+	mi := c.ty.maps[t]
+	mi.Contains = contains
+	mi.Index = index
+	mi.Lookup = lookup
+	mi.Remove = remove
+	mi.Clear = clear
+	c.ty.maps[t] = mi
+}
+
+const mapGrowBy = 16
+const mapMaxCapacity = 0.8

--- a/gapil/compiler/statements.go
+++ b/gapil/compiler/statements.go
@@ -313,19 +313,22 @@ func (c *compiler) mapAssign(s *scope, n *semantic.MapAssign) {
 
 func (c *compiler) mapIteration(s *scope, n *semantic.MapIteration) {
 	mapPtr := c.expression(s, n.Map)
-	count := mapPtr.Index(0, mapCount).Load()
+	capacity := mapPtr.Index(0, mapCapacity).Load()
 	elPtr := mapPtr.Index(0, mapElements).Load()
 	iTy := c.targetType(n.IndexIterator.Type)
-	i := s.Local("i", iTy)
-	s.ForN(count.Cast(iTy), func(it *codegen.Value) *codegen.Value {
-		i.Store(it)
-		k := elPtr.Index(it, "k")
-		v := elPtr.Index(it, "v")
-		s.enter(func(s *scope) {
-			s.locals[n.IndexIterator] = i
-			s.locals[n.KeyIterator] = k
-			s.locals[n.ValueIterator] = v
-			c.block(s, n.Block)
+	i := s.LocalInit("i", s.Scalar(0).Cast(iTy))
+	s.ForN(capacity.Cast(iTy), func(it *codegen.Value) *codegen.Value {
+		used := elPtr.Index(it, "used").Load()
+		s.If(s.Equal(used, s.Scalar(fullBucket)), func() {
+			k := elPtr.Index(it, "k")
+			v := elPtr.Index(it, "v")
+			s.enter(func(s *scope) {
+				s.locals[n.IndexIterator] = i
+				s.locals[n.KeyIterator] = k
+				s.locals[n.ValueIterator] = v
+				c.block(s, n.Block)
+			})
+			i.Store(s.Add(i.Load(), s.Scalar(1).Cast(iTy)))
 		})
 		return nil
 	})

--- a/gapis/api/executor/context.cpp
+++ b/gapis/api/executor/context.cpp
@@ -89,19 +89,21 @@ void gapil_logf(context* ctx, uint8_t severity, uint8_t* fmt, ...) {
 }
 
 void* gapil_alloc(context* ctx, uint64_t size, uint64_t align) {
-    DEBUG_PRINT("gapil_alloc(size: 0x%llx, align: 0x%llx)", size, align);
     auto ec = reinterpret_cast<exec_context*>(ctx);
 
     Arena* arena = reinterpret_cast<Arena*>(ec->arena);
-    return arena->allocate(size, align);
+    void* ptr = arena->allocate(size, align);
+    DEBUG_PRINT("gapil_alloc(size: 0x%llx, align: 0x%llx) -> 0x%p", size, align, ptr);
+    return ptr;
 }
 
 void* gapil_realloc(context* ctx, void* ptr, uint64_t size, uint64_t align) {
-    DEBUG_PRINT("gapil_realloc(ptr: %p, 0x%llx, align: 0x%llx)", ptr, size, align);
     auto ec = reinterpret_cast<exec_context*>(ctx);
 
     Arena* arena = reinterpret_cast<Arena*>(ec->arena);
-    return arena->reallocate(ptr, size, align);
+    void* retptr = arena->reallocate(ptr, size, align);
+    DEBUG_PRINT("gapil_realloc(ptr: %p, 0x%llx, align: 0x%llx) -> 0x%p", ptr, size, align, retptr);
+    return retptr;
 }
 
 void gapil_free(context* ctx, void* ptr) {


### PR DESCRIPTION
This should let us have giant maps without performance penalty.
There are a couple of things to investigate still. The primary one
is how to handle rehashing, we should probably be doubling the
size of the hash map instead of adding a fixed amount, that way when we
get really large arrays, we don't have constant rehashing operations,
which are significantly more expensive than the dynamic array approach.