### PR TITLE
Fix a bug in ~Arena() and a compile error in context.cpp

### DIFF
--- a/core/memory/arena/cc/arena.cpp
+++ b/core/memory/arena/cc/arena.cpp
@@ -45,7 +45,7 @@ Arena::Arena() {}
 
 Arena::~Arena() {
     for (void* ptr : allocations) {
-        free(ptr);
+        ::free(ptr);
     }
     allocations.clear();
 }

--- a/gapil/compiler/map.go
+++ b/gapil/compiler/map.go
@@ -277,7 +277,7 @@ func (c *compiler) buildMapType(t *semantic.Map) {
 			s.If(resize.Load(), func() {
 				// Grow
 				s.IfElse(elements.IsNull(), func() {
-					capacity := s.AddS(capacity, uint64(mapGrowBy))
+					capacity := s.Scalar(uint64(minMapSize))
 					capacityPtr.Store(capacity)
 					elements := c.alloc(s, capacity, elTy)
 					elementsPtr.Store(elements)
@@ -286,7 +286,7 @@ func (c *compiler) buildMapType(t *semantic.Map) {
 						return nil
 					})
 				}, /* else */ func() {
-					newCapacity := s.AddS(capacity, uint64(mapGrowBy))
+					newCapacity := s.MulS(capacity, uint64(mapGrowMultiplier))
 					capacityPtr.Store(newCapacity)
 					newElements := c.alloc(s, newCapacity, elTy)
 					s.ForN(newCapacity, func(it *codegen.Value) *codegen.Value {
@@ -413,5 +413,6 @@ func (c *compiler) buildMapType(t *semantic.Map) {
 	c.ty.maps[t] = mi
 }
 
-const mapGrowBy = 16
+const mapGrowMultiplier = 2
+const minMapSize = 16
 const mapMaxCapacity = 0.8

--- a/gapis/api/executor/context.cpp
+++ b/gapis/api/executor/context.cpp
@@ -18,6 +18,7 @@
 
 #include <stddef.h>
 #include <stdlib.h>
+#include <stdarg.h>
 
 #if 1
 #include <cstdio> // printf debug


### PR DESCRIPTION
Make sure to call the underlying free instead of Arena->free
when clearing pointers, otherwise we will be modifying the
set while traversing it.