### PR TITLE
Add gapil_* functions to libgapii.

### DIFF
--- a/gapii/cc/BUILD.bazel
+++ b/gapii/cc/BUILD.bazel
@@ -88,6 +88,17 @@ apic_template(
 )
 
 cc_library(
+    name = "runtime",
+    srcs = [
+        "runtime/runtime.cpp"
+    ],
+    alwayslink = 1,
+    deps = [
+        "//gapil/runtime/cc",
+    ]
+)
+
+cc_library(
     name = "cc",
     srcs = glob(
         [
@@ -150,6 +161,7 @@ cc_library(
         "//gapis/capture:capture_cc_proto",
         "//gapis/memory/memory_pb:memory_pb_cc_proto",
         "@com_google_protobuf//:protobuf",
+        "runtime",
     ],
 )
 

--- a/gapii/cc/runtime/runtime.cpp
+++ b/gapii/cc/runtime/runtime.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gapil/runtime/cc/runtime.h"
+
+extern "C" {
+
+void* gapil_remap_pointer(context* ctx, uint64_t pointer, uint64_t length) {
+    return reinterpret_cast<void*>(pointer);
+}
+
+void  gapil_get_code_location(context* ctx, char** file, uint32_t* line) {
+}
+
+} // extern "C"


### PR DESCRIPTION
This was causing a failure for tracing Linux.

This adds a force-linked library that makes sure that the symbols
are kept correctly.